### PR TITLE
This PR addresses multiple deprecation warnings and API changes to en…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@ import asyncio
 from datetime import timedelta
 import logging
 
+from aiohttp import ClientConnectionError
 from async_timeout import timeout
 from custom_components.airtouch3.vzduch import Vzduch
 import voluptuous as vol
@@ -12,7 +13,8 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from .const import DOMAIN, TIMEOUT
 from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import Throttle
 
 from . import config_flow  # noqa: F401
@@ -41,7 +43,7 @@ async def async_setup(hass, config):
     )
     return True
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Connect to Airtouch3 Unit"""
     conf = entry.data
 
@@ -53,20 +55,12 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     if not vzduch_api:
         return False
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: vzduch_api})
-    for component in COMPONENT_TYPES:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, COMPONENT_TYPES)
     return True
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    await asyncio.wait(
-        [
-            hass.config_entries.async_forward_entry_unload(config_entry, component)
-            for component in COMPONENT_TYPES
-        ]
-    )
+    await hass.config_entries.async_unload_platforms(config_entry, COMPONENT_TYPES)
     hass.data[DOMAIN].pop(config_entry.entry_id)
     if not hass.data[DOMAIN]:
         hass.data.pop(DOMAIN)
@@ -75,7 +69,7 @@ async def async_unload_entry(hass, config_entry):
 async def api_init(hass, host, port, timeout = TIMEOUT):
     """Init the Airtouch unit."""
 
-    session = hass.helpers.aiohttp_client.async_get_clientsession()
+    session = async_get_clientsession(hass)
     try:
         _LOGGER.debug(f"We have host {host} port {port}")
         device = Vzduch(session, host, port, timeout)

--- a/config_flow.py
+++ b/config_flow.py
@@ -2,10 +2,13 @@ import asyncio
 import logging
 import voluptuous as vol
 
+from aiohttp import web_exceptions, ClientError
 from async_timeout import timeout
 from custom_components.airtouch3.vzduch import Vzduch
 
-from homeassistant import config_entries, core
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from . import config_flow
@@ -20,7 +23,7 @@ class AirTouch3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
-    @core.callback
+    @callback
     def _async_get_entry(self, data):
 
         return self.async_create_entry(
@@ -42,7 +45,7 @@ class AirTouch3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             _LOGGER.debug("create_device")
-            session = self.hass.helpers.aiohttp_client.async_get_clientsession()
+            session = async_get_clientsession(self.hass)
             with timeout(TIMEOUT):
                 _LOGGER.debug("Call vzduch")
                 device = Vzduch(session, host, port, timeout)
@@ -76,7 +79,7 @@ class AirTouch3ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def create_device(self, host, port=DEFAULT_PORT):
         try:
             _LOGGER.debug("create_device")
-            session = self.hass.helpers.aiohttp_client.async_get_clientsession()
+            session = async_get_clientsession(self.hass)
             with timeout(TIMEOUT):
                 _LOGGER.debug("Call vzduch")
                 device = await Vzduch(session, host, port, timeout)


### PR DESCRIPTION
**Compatibility with Home Assistant 2025.x and newer versions.**

Changes Made

**1. Fixed Deprecated HomeAssistantType Import Files: __init__.py**

Change: Replaced deprecated HomeAssistantType with homeassistant.core.HomeAssistant Impact: Eliminates deprecation warning about HomeAssistantType being removed in HA Core 2025.5

**2. Fixed Incorrect aiohttp Client Session Access Files: config_flow.py, __init__.py**

Issue: AttributeError: 'HomeAssistant' object has no attribute 'helpers' Solution:
Added proper import: from homeassistant.helpers.aiohttp_client import async_get_clientsession Changed hass.helpers.aiohttp_client.async_get_clientsession() to async_get_clientsession(hass) Impact: Fixes runtime errors when setting up the integration

**3. Added Missing Exception Imports Files: config_flow.py, __init__.py**

Added:
from aiohttp import web_exceptions, ClientError in config_flow.py from aiohttp import ClientConnectionError in __init__.py Impact: Fixes NameError: name 'web_exceptions' is not defined and related import errors

**4. Updated Platform Setup/Unload Methods Files: __init__.py**

Changes:
Replaced deprecated async_forward_entry_setup() with async_forward_entry_setups() Replaced individual async_forward_entry_unload() calls with async_unload_platforms() Simplified setup logic by removing unnecessary hass.async_create_task() wrappers Impact: Fixes AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'

**5. Fixed Deprecated Callback Decorator Files: config_flow.py**

Change: Replaced @core.callback with @callback and updated imports Impact: Uses current Home Assistant API conventions Testing
<input checked="" disabled="" type="checkbox"> Integration loads without errors <input checked="" disabled="" type="checkbox"> Config flow works properly <input checked="" disabled="" type="checkbox"> No deprecation warnings in logs <input checked="" disabled="" type="checkbox"> Platform setup/unload functions correctly Backward Compatibility
These changes maintain backward compatibility while using the modern Home Assistant APIs introduced in recent versions.

**Resolves**

AttributeError: 'HomeAssistant' object has no attribute 'helpers' AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup' NameError: name 'web_exceptions' is not defined
HomeAssistantType deprecation warning